### PR TITLE
Añadir al tag router la posibilidad the entregar los tags de acuerdo a page, limit y searchQuery

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,18 +1,17 @@
 const server = require('./src/app.js')
-const { conn, Videogame, Tag, Genre } = require('./src/db.js')
-const {
-  uploadVideogames,
-  uploadTags,
-  uploadGenres,
-} = require('./src/utils/helpers.js')
+const { conn } = require('./src/db.js')
+// const {
+//   uploadVideogames,
+//   uploadTags,
+//   uploadGenres,
+// } = require('./src/utils/helpers.js')
 
 const PORT = 3001
 
-// Syncing all the models at once.
-conn.sync({ force: true }).then(() => {
-  uploadGenres(Genre)
-  uploadTags(Tag)
-  uploadVideogames(Videogame)
+conn.sync({ force: false }).then(() => {
+  // uploadGenres(Genre)
+  // uploadTags(Tag)
+  // uploadVideogames(Videogame)
 
   server.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`)

--- a/api/src/controllers/tagControllers.js
+++ b/api/src/controllers/tagControllers.js
@@ -1,14 +1,25 @@
-const { Tag }= require('../db');
+const { Tag } = require('../db')
+const { Op } = require('sequelize')
 
-const getTags = async () => {
-    try {
-        let allTags = await Tag.findAll();
-        return allTags;
-    } catch (error) {
-        return {error: error.message}
+const getTags = async ({ searchQuery = '', page = 1, limit = 10 }) => {
+    if (isNaN(page) || isNaN(limit)) {
+        throw new Error('Page or limit must be numbers')
     }
-};
+
+    try {
+        let foundedTags = await Tag.findAll({
+            where: { name: { [Op.iLike]: `%${searchQuery}%` } },
+            offset: (page - 1) * limit,
+            limit,
+            order: [['id', 'ASC']],
+        })
+
+        return foundedTags
+    } catch (error) {
+        return { error: error.message }
+    }
+}
 
 module.exports = {
-    getTags
-};
+    getTags,
+}

--- a/api/src/routes/tagRouter.js
+++ b/api/src/routes/tagRouter.js
@@ -1,13 +1,15 @@
-const tagRouter = require('express').Router();
-const { getTags } = require('../controllers/tagControllers');
+const tagRouter = require('express').Router()
+const { getTags } = require('../controllers/tagControllers')
 
-tagRouter.get('/', async (req, res) =>{
+tagRouter.get('/', async (req, res) => {
+    const { limit, page, searchQuery } = req.query
+
     try {
-        const tags = await getTags();
+        const tags = await getTags({ limit, page, searchQuery })
 
-        res.status(200).json(tags);
+        res.status(200).json(tags)
     } catch (error) {
-        res.status(404).send(error.message)
+        res.status(500).json({ error: error.message })
     }
 })
 


### PR DESCRIPTION
si no se le pasa el searchQuery devuelve todos los datos, si no se le pasa el limit devuelve 10 tags, si no se le pasa page devuelve la primera.
ejemplos:
- `http://localhost:3001/tag`  devuelve 10 tags by default.
- `http://localhost:3001/tag?searchQuery=ad` devuelve 10 tags que coincida con `ad`
- `http://localhost:3001/tag?searchQuery=ad78&page=2&limit=15` devuelve los segundos 15 tags que coincida con `ad` o `[]` 